### PR TITLE
Version release v3.0.0-beta-20200206

### DIFF
--- a/cmp/bidsappmanager/pipelines/functional/fMRI.py
+++ b/cmp/bidsappmanager/pipelines/functional/fMRI.py
@@ -113,6 +113,7 @@ class fMRIPipelineUI(fMRIPipeline):
             subject = "_".join((self.subject,self.global_conf.subject_session))
 
         fmri_file = os.path.join(self.subject_directory,'func',subject+'_task-rest_bold.nii.gz')
+        json_file = os.path.join(self.subject_directory,'func',subject+'_task-rest_bold.json')
         t1_file = os.path.join(self.subject_directory,'anat',subject+'_T1w.nii.gz')
         t2_file = os.path.join(self.subject_directory,'anat',subject+'_T2w.nii.gz')
 

--- a/cmp/info.py
+++ b/cmp/info.py
@@ -3,7 +3,7 @@
 _version_major = 3
 _version_minor = 0
 _version_micro = 0
-_version_extra = '-beta-20200124'
+_version_extra = '-beta-20200206'
 
 __release_date__ = '14.05.2019'
 

--- a/cmp/pipelines/functional/fMRI.py
+++ b/cmp/pipelines/functional/fMRI.py
@@ -143,6 +143,7 @@ class fMRIPipeline(Pipeline):
             subject = "_".join((self.subject,self.global_conf.subject_session))
 
         fmri_file = os.path.join(self.subject_directory,'func',subject+'_task-rest_bold.nii.gz')
+        json_file = os.path.join(self.subject_directory,'func',subject+'_task-rest_bold.json')
         t1_file = os.path.join(self.subject_directory,'anat',subject+'_T1w.nii.gz')
         t2_file = os.path.join(self.subject_directory,'anat',subject+'_T2w.nii.gz')
 
@@ -530,19 +531,19 @@ class fMRIPipeline(Pipeline):
                           (fMRI_inputnode,reg_flow,[('T1','inputnode.T1')]),(fMRI_inputnode,reg_flow,[('T2','inputnode.T2')]),
                           (preproc_flow,reg_flow, [('outputnode.mean_vol','inputnode.target')]),
                           (fMRI_inputnode,reg_flow, [('wm_mask_file','inputnode.wm_mask'),('roi_volumes','inputnode.roi_volumes'),
-                                                ('wm_eroded','inputnode.eroded_wm')]),
+                                                ('brain_eroded','inputnode.eroded_brain'),('wm_eroded','inputnode.eroded_wm'),('csf_eroded','inputnode.eroded_csf')]),
                           (reg_flow,sinker, [('outputnode.wm_mask_registered_crop','anat.@registered_wm'),('outputnode.roi_volumes_registered_crop','anat.@registered_roi_volumes'),
                                                  ('outputnode.eroded_wm_registered_crop','anat.@eroded_wm'),('outputnode.eroded_csf_registered_crop','anat.@eroded_csf'),
                                                  ('outputnode.eroded_brain_registered_crop','anat.@eroded_brain')]),
                           ])
-            if self.stages['FunctionalMRI'].config.global_nuisance:
-                fMRI_flow.connect([
-                              (fMRI_inputnode,reg_flow,[('brain_eroded','inputnode.eroded_brain')])
-                            ])
-            if self.stages['FunctionalMRI'].config.csf:
-                fMRI_flow.connect([
-                              (fMRI_inputnode,reg_flow,[('csf_eroded','inputnode.eroded_csf')])
-                            ])
+            # if self.stages['FunctionalMRI'].config.global_nuisance:
+            #     fMRI_flow.connect([
+            #                   (fMRI_inputnode,reg_flow,[('brain_eroded','inputnode.eroded_brain')])
+            #                 ])
+            # if self.stages['FunctionalMRI'].config.csf:
+            #     fMRI_flow.connect([
+            #                   (fMRI_inputnode,reg_flow,[('csf_eroded','inputnode.eroded_csf')])
+            #                 ])
             if self.stages['Registration'].config.registration_mode == "BBregister (FS)":
                 fMRI_flow.connect([
                           (fMRI_inputnode,reg_flow, [('subjects_dir','inputnode.subjects_dir'),

--- a/cmp/stages/functional/functionalMRI.py
+++ b/cmp/stages/functional/functionalMRI.py
@@ -510,15 +510,22 @@ class FunctionalMRIStage(Stage):
 
         filter_output = pe.Node(interface=util.IdentityInterface(fields=["filter_output"]),name="filter_output")
         if self.config.lowpass_filter > 0 or self.config.highpass_filter > 0:
-            filtering = pe.Node(interface=afni.Bandpass(out_file='fMRI_bandpass+orig.BRIK'),name='temporal_filter')
+            from cmtklib.interfaces.afni import Bandpass
+            filtering = pe.Node(interface=Bandpass(),name='temporal_filter')
+            #filtering = pe.Node(interface=afni.Bandpass(),name='temporal_filter')
             converter = pe.Node(interface=afni.AFNItoNIFTI(out_file='fMRI_bandpass.nii.gz'), name='converter')
             # FIXME: Seems that lowpass and highpass inputs of the nipype 3DBandPass interface swaped low and high frequencies
             filtering.inputs.lowpass = self.config.highpass_filter
             filtering.inputs.highpass = self.config.lowpass_filter
-            if self.config.detrending:
-                filtering.inputs.no_detrend = True
+            
+            #if self.config.detrending:
+            #    filtering.inputs.no_detrend = True
+            
+            filtering.inputs.no_detrend = True
+
             flow.connect([
                         (nuisance_output,filtering,[("nuisance_output","in_file")]),
+                        #(filtering,filter_output,[("out_file","filter_output")])
                         (filtering,converter,[("out_file","in_file")]),
                         (converter,filter_output,[("out_file","filter_output")])
                         ])

--- a/cmtklib/interfaces/afni.py
+++ b/cmtklib/interfaces/afni.py
@@ -1,0 +1,150 @@
+# Copyright (C) 2017-2020, Brain Communication Pathways Sinergia Consortium, Switzerland
+# All rights reserved.
+#
+#  This software is distributed under the open-source license Modified BSD.
+
+""" The AFNI module provides functions for interfacing with AFNI toolbox missing in nipype or modified
+"""
+
+import os
+from sys import platform
+from builtins import object
+from future.utils import raise_from
+
+from nipype import logging
+from nipype.utils.filemanip import split_filename
+from nipype.interfaces.base import (
+    CommandLine, traits, CommandLineInputSpec, isdefined, File, TraitedSpec,
+    InputMultiPath, Undefined, Str, InputMultiObject, PackageInfo)
+from nipype.external.due import BibTeX
+
+from nipype.interfaces.afni.base import (AFNICommand, 
+										AFNICommandInputSpec, 
+										AFNICommandOutputSpec)
+
+
+# Use nipype's logging system
+IFLOGGER = logging.getLogger('interface')
+
+
+class BandpassInputSpec(AFNICommandInputSpec):
+    in_file = File(
+        desc='input file to 3dBandpass',
+        argstr='%s',
+        position=-1,
+        mandatory=True,
+        exists=True,
+        copyfile=False)
+    out_file = File(
+        name_template='%s_bp',
+        desc='output file from 3dBandpass',
+        argstr='-prefix %s',
+        position=1,
+        name_source='in_file',
+        genfile=True)
+    lowpass = traits.Float(
+        desc='lowpass',
+        argstr='%f',
+        position=-2,
+        mandatory=True)
+    highpass = traits.Float(
+        desc='highpass',
+        argstr='%f',
+        position=-3,
+        mandatory=True)
+    mask = File(
+        desc='mask file',
+        position=2,
+        argstr='-mask %s',
+        exists=True)
+    despike = traits.Bool(
+        argstr='-despike',
+        desc="""Despike each time series before other processing.
+                  ++ Hopefully, you don't actually need to do this,
+                     which is why it is optional.""")
+    orthogonalize_file = InputMultiPath(
+        File(exists=True),
+        argstr="-ort %s",
+        desc="""Also orthogonalize input to columns in f.1D
+                   ++ Multiple '-ort' options are allowed.""")
+    orthogonalize_dset = File(
+        exists=True,
+        argstr="-dsort %s",
+        desc="""Orthogonalize each voxel to the corresponding
+                   voxel time series in dataset 'fset', which must
+                   have the same spatial and temporal grid structure
+                   as the main input dataset.
+                   ++ At present, only one '-dsort' option is allowed.""")
+    no_detrend = traits.Bool(
+        argstr='-nodetrend',
+        desc="""Skip the quadratic detrending of the input that
+                    occurs before the FFT-based bandpassing.
+                   ++ You would only want to do this if the dataset
+                      had been detrended already in some other program.""")
+    tr = traits.Float(
+        argstr="-dt %f",
+        desc="set time step (TR) in sec [default=from dataset header]")
+    nfft = traits.Int(
+        argstr='-nfft %d',
+        desc="set the FFT length [must be a legal value]")
+    normalize = traits.Bool(
+        argstr='-norm',
+        desc="""Make all output time series have L2 norm = 1
+                   ++ i.e., sum of squares = 1""")
+    automask = traits.Bool(
+        argstr='-automask',
+        desc="Create a mask from the input dataset")
+    blur = traits.Float(
+        argstr='-blur %f',
+        desc="""Blur (inside the mask only) with a filter
+                    width (FWHM) of 'fff' millimeters.""")
+    localPV = traits.Float(
+        argstr='-localPV %f',
+        desc="""Replace each vector by the local Principal Vector
+                    (AKA first singular vector) from a neighborhood
+                    of radius 'rrr' millimiters.
+                   ++ Note that the PV time series is L2 normalized.
+                   ++ This option is mostly for Bob Cox to have fun with.""")
+    notrans = traits.Bool(
+        argstr='-notrans',
+        desc="""Don't check for initial positive transients in the data:
+                   ++ The test is a little slow, so skipping it is OK,
+                   if you KNOW the data time series are transient-free.""")
+
+
+class Bandpass(AFNICommand):
+    """Program to lowpass and/or highpass each voxel time series in a
+    dataset, offering more/different options than Fourier
+    For complete details, see the `3dBandpass Documentation.
+    <http://afni.nimh.nih.gov/pub/dist/doc/program_help/3dbandpass.html>`_
+    Examples
+    ========
+    >>> from nipype.interfaces import afni as afni
+    >>> from nipype.testing import  example_data
+    >>> bandpass = afni.Bandpass()
+    >>> bandpass.inputs.in_file = example_data('functional.nii')
+    >>> bandpass.inputs.highpass = 0.005
+    >>> bandpass.inputs.lowpass = 0.1
+    >>> res = bandpass.run() # doctest: +SKIP
+    """
+
+    _cmd = '3dBandpass'
+    input_spec = BandpassInputSpec
+    output_spec = AFNICommandOutputSpec
+
+    def _list_outputs(self):
+    	outputs = self._outputs().get()
+     	name = 'out_file'
+     	if isdefined(self.inputs.out_file):
+     		if outputs[name]:
+                	print('out_file: {}'.format(outputs[name]))
+                	_, base, ext = split_filename(outputs[name])
+                	if ext == "":
+                		outputs[name] = outputs[name] + "+orig.BRIK"
+        else:
+        	from glob import glob
+        	files = sorted(glob("*.BRIK"))
+        	print("files: {}".format(files))
+        	if len(files) > 0:
+        		outputs[name] = os.path.abspath(files[0])
+        return outputs

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,7 +3,18 @@ Changes
 ========
 
 *************************
-Version 3.0.0-beta-240120
+Version 3.0.0-beta-20200206
+*************************
+
+Date: February 06, 2020
+
+* Implementation of an in-house Nipype interface to AFNI 3DBandPass which can handle to check output as ..++orig.BRIK or as ..tlrc.BRIK (The later can occur with HCP preprocessed fmri data)
+
+* Updated documentation with list of changes
+
+
+*************************
+Version 3.0.0-beta-20200124
 *************************
 
 Date: January 24, 2020


### PR DESCRIPTION
Fix an error when executing the Nipype interface to AFNI 3DBandPass on HCP fmri preprocessed data.

 **Error**
HCP fmri preprocessed data lies in MNI space. 
Consequently 3DBandPass outputs are in talairach space and generates automatically output with suffix and extension +tlrc.BRIK.
However, the Nipype interface looks for outputs with suffix and extension +orig.BRIK for successful execution raising the error

**Solution**
As a first hot fix, an in-house interface to 3DBandPass is implemented, where we overload the _list_outputs() function to look for either +orig.BRIK or +tlrc.BRIK output files