### PR TITLE
ENH: add options to BIDS App to fix multiple envvars

### DIFF
--- a/cmp/parser.py
+++ b/cmp/parser.py
@@ -26,7 +26,7 @@ def get():
                                     'formatted according to the BIDS standard.')
     p.add_argument('output_dir', help='The directory where the output files '
                                       'should be stored. If you are running group level analysis '
-                                      'this folder should be prepopulated with the results of the'
+                                      'this folder should be prepopulated with the results of the '
                                       'participant level analysis.')
     p.add_argument('analysis_level', help='Level of the analysis that will be performed. '
                                           'Multiple participant level analyses can be run independently '
@@ -54,12 +54,33 @@ def get():
     p.add_argument('--func_pipeline_config',
                    help='Configuration .txt file for processing stages of the fMRI processing pipeline')
 
-    p.add_argument('--number_of_threads', type=int, help='The number of OpenMP threads used for multi-threading by'
-                                                         'Freesurfer, FSL, MRtrix3, Dipy, AFNI'
-                                                         '(Set to [Number of available CPUs -1] by default).')
+    p.add_argument('--number_of_threads',
+                   type=int,
+                   help='The number of OpenMP threads used for multi-threading by '
+                        'Freesurfer, FSL, MRtrix3, Dipy, AFNI '
+                        '(Set to [Number of available CPUs -1] by default).')
 
-    p.add_argument('--number_of_participants_processed_in_parallel', type=int, help='The number of subjects '
-                                                                                    'to be processed in parallel (One by default).')
+    p.add_argument('--number_of_participants_processed_in_parallel',
+                   type=int,
+                   help='The number of subjects to be processed in parallel (One by default).')
+
+    p.add_argument('--set_mrtrix_rng_seed',
+                   type=int,
+                   help='Fix MRtrix3 random number generator seed')
+
+    p.add_argument('--set_ants_random_seed',
+                   type=int,
+                   help='Fix ANTS random number generator seed ')
+
+    p.add_argument('--set_itk_global_default_number_of_threads',
+                   default=1,
+                   type=int,
+                   help='Fix number of threads used by ANTs')
+
+    p.add_argument('--set_mkl_num_threads',
+                   type=int,
+                   default=1,
+                   help='Fix number of MKL threads')
 
     p.add_argument('--fs_license', help='Freesurfer license.txt')
 

--- a/run.py
+++ b/run.py
@@ -374,6 +374,24 @@ else:
 os.environ['OMP_NUM_THREADS'] = '{}'.format(number_of_threads)
 print('  * OMP_NUM_THREADS set to {} (total of cores: {})'.format(os.environ['OMP_NUM_THREADS'], max_number_of_cores))
 
+# Set random generator seed of MRtrix if specified
+if args.set_mrtrix_rng_seed is not None:
+    os.environ['MRTRIX_RNG_SEED'] = f'{args.set_mrtrix_rng_seed}'
+    print(f'  * MRTRIX_RNG_SEED set to {os.environ["MRTRIX_RNG_SEED"]}')
+
+# Set random generator seed of ANTs if specified
+if args.set_ants_random_seed is not None:
+    os.environ['ANTS_RANDOM_SEED'] = f'{args.set_ants_random_seed}'
+    print(f'  * ANTS_RANDOM_SEED set to {os.environ["ANTS_RANDOM_SEED"]}')
+
+# Set number of threads used by ITK (1 by default)
+os.environ['ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS'] = f'{args.set_itk_global_default_number_of_threads}'
+print(f'  * ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS set to {os.environ["ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS"]}')
+
+# Set number of MKL threads (1 by default)
+os.environ['MKL_NUM_THREADS'] = f'{args.set_ants_random_seed}'
+print(f'  * MKL_NUM_THREADS set to {os.environ["MKL_NUM_THREADS"]}')
+
 # TODO: Implement log for subject(_session)
 # with open(log_filename, 'w+') as log:
 #     proc = Popen(cmd, stdout=log, stderr=log, cwd=os.path.join(self.bids_root,'derivatives'))

--- a/run.py
+++ b/run.py
@@ -389,7 +389,7 @@ os.environ['ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS'] = f'{args.set_itk_global_defa
 print(f'  * ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS set to {os.environ["ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS"]}')
 
 # Set number of MKL threads (1 by default)
-os.environ['MKL_NUM_THREADS'] = f'{args.set_ants_random_seed}'
+os.environ['MKL_NUM_THREADS'] = f'{args.set_mkl_num_threads}'
 print(f'  * MKL_NUM_THREADS set to {os.environ["MKL_NUM_THREADS"]}')
 
 # TODO: Implement log for subject(_session)


### PR DESCRIPTION
This PR adds new options to the BIDS App to gain more control on its execution in terms of reproducibility as suggested in https://doi.org/10.1016/j.neuroimage.2020.116889. 

This includes the setting of:
* the random generator seeds used by mrtrix (`--set_mrtrix_rng_seed`), 
* the random generator seeds used by ants (`--set_ants_random_seed`), 
* the number of threads used by ITK-based tools (`--set_itk_global_default_number_of_threads`)
* the number of MKL threads (`--set_mkl_num_threads`).