### PR TITLE
FIX mutable default argument fix in showmatrix_gpicke

### DIFF
--- a/cmp/cli/showmatrix_gpickle.py
+++ b/cmp/cli/showmatrix_gpickle.py
@@ -29,7 +29,7 @@ def _plot_connectivity_circle_onpick(event,
                                      fig=None, axes=None,
                                      indices=None,
                                      node_angles=None,
-                                     ylim=[9, 10]):
+                                     ylim=None):
     """Isolate connections around a single node when user left clicks a node.
 
     On right click, resets all connections.
@@ -43,6 +43,9 @@ def _plot_connectivity_circle_onpick(event,
     #
     # Modified by:
     #          Sebastien Tourbier <sebastien.tourbier@alumni.epfl.ch>
+
+    if ylim is None:
+        ylim = [9, 10]
 
     if event.inaxes != axes:
         return


### PR DESCRIPTION
Fix the use of mutable default value as an argument,

References
------------

* PyLint - W0102, dangerous-default-value
* Stack Overflow - Hidden Features of Python