### PR TITLE
CI: Set docker_layer_caching to false

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,7 +386,7 @@ jobs:
       SCRATCH: "/scratch"
     machine:
       image: ubuntu-1604:201903-01
-      docker_layer_caching: true
+      docker_layer_caching: false
     resource_class: medium
     working_directory: /home/circleci/src/connectomemapper3
     steps:


### PR DESCRIPTION
Do not use docker layer caching with BUILDKIT as an error occured on circleci for the latest PRs.