### PR TITLE
FIX: Add missing `cmp.stages.eeg` to `setup_pypi.py`

### DIFF
--- a/setup_pypi.py
+++ b/setup_pypi.py
@@ -43,6 +43,7 @@ packages = [
     "cmp.stages.diffusion",
     "cmp.stages.functional",
     "cmp.stages.connectome",
+    "cmp.stages.eeg",
     "cmp.pipelines",
     "cmp.pipelines.anatomical",
     "cmp.pipelines.diffusion",


### PR DESCRIPTION
This PR resolves #150 #160.

It adds `cmp.stages.eeg` to the list of packages in setup_pypi.py (which is used to create the connectomemapper package published on PyPI). 