### PR TITLE
DOC: Refer to contributing guidelines in README [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,10 @@ Thanks also goes to all these wonderful people that contributed to Connectome Ma
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
 
+### How to contribute?
+
+Please consult our [Contributing to Connectome Mapper 3](https://connectome-mapper-3.readthedocs.io/en/latest/contributing.html#) guidelines.
+
 ### Funding
 
 Work supported by the [Sinergia SNFNS-170873 Grant](http://p3.snf.ch/Project-170873).


### PR DESCRIPTION
This PR resolves #159. 

It adds a "How to contribute?" section with a link to the contributing guidelines.