### PR TITLE
DOC: Use `sphinx-copybutton` extension in the documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -370,10 +370,10 @@ intersphinx_mapping = {"http://docs.python.org/3": None}
 
 # -- sphinx-copybutton extension configuration -------------------------------
 
-copybutton_prompt_text = r">>> |\.\.\. |\$ | |(py37cmp-gui)\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_text = r">>> |\.\.\. |\$ | |\(py37cmp-gui\)\$ "
 copybutton_prompt_is_regexp = True
 # copybutton_only_copy_prompt_lines = False
-# copybutton_remove_prompts = False
+copybutton_remove_prompts = True
 # copybutton_copy_empty_lines = False
 # copybutton_line_continuation_character = "\\"
 # copybutton_here_doc_delimiter = "EOT"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,6 +62,7 @@ extensions = [
     'sphinxarg.ext',
     'sphinx.ext.inheritance_diagram',
     'sphinxcontrib.apidoc',
+    'sphinx_copybutton',
     'matplotlib.sphinxext.plot_directive',
     'nbsphinx',
     'sphinx_gallery.load_style',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -366,3 +366,19 @@ apidoc_extra_args = ["--module-first",
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {"http://docs.python.org/3": None}
+
+
+# -- sphinx-copybutton extension configuration -------------------------------
+
+# copybutton_prompt_text = "myinputprompt"
+# copybutton_prompt_text = ">>> "
+# copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+# copybutton_prompt_is_regexp = True
+# copybutton_only_copy_prompt_lines = False
+# copybutton_remove_prompts = False
+# copybutton_copy_empty_lines = False
+# copybutton_line_continuation_character = "\\"
+# copybutton_here_doc_delimiter = "EOT"
+
+# See https://sphinx-copybutton.readthedocs.io/en/latest/use.html#keep-empty-lines
+# for more details

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -370,10 +370,8 @@ intersphinx_mapping = {"http://docs.python.org/3": None}
 
 # -- sphinx-copybutton extension configuration -------------------------------
 
-# copybutton_prompt_text = "myinputprompt"
-# copybutton_prompt_text = ">>> "
-# copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
-# copybutton_prompt_is_regexp = True
+copybutton_prompt_text = r">>> |\.\.\. |\$ | |(py37cmp-gui)\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True
 # copybutton_only_copy_prompt_lines = False
 # copybutton_remove_prompts = False
 # copybutton_copy_empty_lines = False

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,6 +8,7 @@ sphinx-gallery==0.10.1
 recommonmark==0.7.1
 readthedocs-sphinx-ext==2.1.4
 sphinx-autodoc-typehints==1.12.0
+sphinx-copybutton==0.5.0
 traits==6.3.2
 traitsui==7.2.0
 grabbit


### PR DESCRIPTION
This PR resolves #157.

It incorporates the use of [sphinx-copybutton](https://sphinx-copybutton.readthedocs.io/en/latest/) to make copy of the code blocks more easy by automatically adding a copy button to all code blocks in the documentation .