### PR TITLE
FIX: Add missing package data for parcellation in setup_pypi.py

### DIFF
--- a/setup_pypi.py
+++ b/setup_pypi.py
@@ -80,6 +80,9 @@ package_data = {
     ],
     "resources": ["buttons/*.png", "icons/*png"],
     "cmtklib": [
+        "data/parcellation/lausanne2018/*.*",
+        "data/parcellation/lausanne2018/*/*.*",
+        "data/parcellation/nativefreesurfer/*/*.*",
         "data/parcellation/lausanne2018/mni-space/*.*",
         "data/report/carbonfootprint/css/*.*",
         "data/report/carbonfootprint/js/*.*",


### PR DESCRIPTION
This PR resolves #179 by adding the missing annot files for all parcellation in `setup_pypi.py`.