### PR TITLE
FIX: Correct command to install the conda environment in tutorial notebooks

### DIFF
--- a/docs/notebooks/EEG_pipeline_tutorial.ipynb
+++ b/docs/notebooks/EEG_pipeline_tutorial.ipynb
@@ -27,7 +27,7 @@
     "\n",
     "Once you have downloaded the conda environment file, install the environment `py37cmp-eeg` as follows:\n",
     "```bash\n",
-    "$ conda create env -f /path/to/downloaded/EEG_tutorial_environment.yml\n",
+    "$ conda env create -f /path/to/downloaded/EEG_tutorial_environment.yml\n",
     "```\n",
     "This will install all the packages needed to run this notebook including jupyter lab.\n",
     "\n",

--- a/docs/notebooks/analysis_tutorial.ipynb
+++ b/docs/notebooks/analysis_tutorial.ipynb
@@ -26,7 +26,7 @@
     "\n",
     "Once you have downloaded the conda environment file, install the environment as follows:\n",
     "```bash\n",
-    "$ conda create env -f /path/to/downloaded/analysis_tutorial.yml\n",
+    "$ conda env create -f /path/to/downloaded/analysis_tutorial.yml\n",
     "```\n",
     "This will install all the packages needed to run this notebook including jupyter lab.\n",
     "\n",


### PR DESCRIPTION
This PR resolves #185. 