### PR TITLE
FIX: Use PyQt5 to be able to launch `cmpbidsappmanager` on Mac Big Sur

### DIFF
--- a/cmp/cli/cmpbidsappmanager.py
+++ b/cmp/cli/cmpbidsappmanager.py
@@ -13,12 +13,16 @@ from distutils.version import StrictVersion
 from pathlib import Path
 import subprocess
 
-# Setup Qt5/Pyside2 backend for traitsui
+# Setup Qt5 backend for traitsui
 from traits.etsconfig.api import ETSConfig
 ETSConfig.toolkit = "qt"  # pylint: disable=E402 # noqa
 os.environ["ETS_TOOLKIT"] = "qt"  # pylint: disable=E402 # noqa
-# os.environ['QT_API'] = 'pyqt5'
-os.environ["QT_API"] = "pyside2"  # pylint: disable=E402 # noqa
+os.environ['QT_API'] = 'pyqt5'  # pylint: disable=E402 # noqa
+
+from PyQt5.QtCore import (
+    QT_VERSION_STR,
+    PYQT_VERSION_STR
+)
 
 # CMP imports
 from cmp.info import __version__, __copyright__
@@ -33,7 +37,8 @@ def _info():
     print_warning("""{}""".format(__copyright__))
     print_warning("------------------------------------------------------")
     print("------------------------------------------------------")
-    print("  .. INFO: Use {} for graphical backend".format(ETSConfig.toolkit))
+    print(f"  .. INFO: Use {ETSConfig.toolkit} ({PYQT_VERSION_STR}) / "
+          f"{os.environ['QT_API']} ({QT_VERSION_STR}) for graphical backend")
     print("------------------------------------------------------\n")
 
 
@@ -124,6 +129,8 @@ def main():
         python_path = Path(sys.exec_prefix) / 'bin' / 'pythonw'
 
         if python_path.exists():
+            # Required for macOS Big Sur: https://stackoverflow.com/a/64878899
+            os.environ["QT_MAC_WANTS_LAYER"] = "1"
             # Running again with pythonw will exit this script
             # and use the framework build of python.
             _run_pythonw(python_path)

--- a/cmp/cli/cmpbidsappmanager.py
+++ b/cmp/cli/cmpbidsappmanager.py
@@ -37,8 +37,8 @@ def _info():
     print_warning("""{}""".format(__copyright__))
     print_warning("------------------------------------------------------")
     print("------------------------------------------------------")
-    print(f"  .. INFO: Use {ETSConfig.toolkit} ({PYQT_VERSION_STR}) / "
-          f"{os.environ['QT_API']} ({QT_VERSION_STR}) for graphical backend")
+    print(f"  .. INFO: Use {ETSConfig.toolkit} ({QT_VERSION_STR}) / "
+          f"{os.environ['QT_API']} ({PYQT_VERSION_STR}) for graphical backend")
     print("------------------------------------------------------\n")
 
 

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -4,28 +4,25 @@ channels:
     - conda-forge
     - aramislab
     - mrtrix3
-    - anaconda
 
 dependencies:
     - python=3.7
     - pip=21.3.1
-    - numpy=1.21.5
-    - matplotlib=3.5.1
-    - traits=6.3.2
-    - traitsui=7.2.0
     - graphviz=2.50.0
-    - configparser=5.2.0
-    - nipype=1.7.0
-    - git-annex=8.20211123
-    - pyside2=5.13.2
-    - indexed_gzip=1.6.4
     - dipy=1.3.0
-    - cvxpy-base=1.1.18
-    - cvxpy=1.1.18
     - fsleyes=1.3.3
+    - indexed_gzip=1.6.4
     - mrtrix3=3.0.3
+    - git-annex=8.20211123
 
     - pip:
+          - numpy==1.21.6
+          - matplotlib==3.5.2
+          - configparser==5.2.0
+          - nipype==1.8.0
+          - traits==6.3.2
+          - traitsui==7.2.0
+          - PyQt5==5.15.6
           - duecredit==0.9.1
           - obspy==1.2.2
           - mne==0.24.1

--- a/conda/environment_macosx.yml
+++ b/conda/environment_macosx.yml
@@ -4,27 +4,24 @@ channels:
     - conda-forge
     - aramislab
     - mrtrix3
-    - anaconda
 
 dependencies:
     - python=3.7
     - pip=21.3.1
-    - numpy=1.21.5
-    - matplotlib=3.5.1
-    - traits=6.3.2
-    - traitsui=7.2.0
     - graphviz=2.50.0
-    - configparser=5.2.0
-    - nipype=1.7.0
-    - pyside2=5.13.2
-    - indexed_gzip=1.6.4
     - dipy=1.3.0
-    - cvxpy-base=1.1.18
-    - cvxpy=1.1.18
     - fsleyes=1.3.3
+    - indexed_gzip=1.6.4
     - mrtrix3=3.0.3
 
     - pip:
+          - numpy==1.21.6
+          - matplotlib==3.5.2
+          - configparser==5.2.0
+          - nipype==1.8.0
+          - traits==6.3.2
+          - traitsui==7.2.0
+          - PyQt5==5.15.6
           - duecredit==0.9.1
           - obspy==1.2.2
           - mne==0.24.1


### PR DESCRIPTION
This PR resolves #171 by integrating the suggested fix in https://github.com/connectomicslab/connectomemapper3/issues/171#issuecomment-1121300851 that consists of using the latest version PyQt5 instead of PySide2 for graphical backend.

The conda environment files have also been refactor, Pyside2 is not installed anymore, and a number of packages are now installed directly via pip, including PyQt5.