### PR TITLE
FIX: Problem to launch `cmpbidsappmanager` in Ubuntu 18.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Since ``v3.1.0``, CMP3 provides full support to EEG. Please check [this notebook
 
 You need to have first either Docker or Singularity engine and miniconda installed. We refer to the [dedicated documentation page](https://connectome-mapper-3.readthedocs.io/en/latest/installation.html) for more instruction details.
 
-Then, download the appropriate [environment.yml](https://github.com/connectomicslab/connectomemapper3/raw/master/conda/environment.yml) / [environment_macosx.yml](https://github.com/connectomicslab/connectomemapper3/raw/master/conda/environment_macosx.yml) and create a conda environment `py37cmp-gui` with the following command:
+Then, download the appropriate [environment.yml](https://github.com/connectomicslab/connectomemapper3/raw/master/conda/environment.yml) / [environment_macosx.yml](https://github.com/connectomicslab/connectomemapper3/raw/master/conda/environment_macosx.yml) and create a conda environment `py39cmp-gui` with the following command:
 
 ```bash
 $ conda env create -f /path/to/environment[_macosx].yml
@@ -31,8 +31,8 @@ $ conda env create -f /path/to/environment[_macosx].yml
 Once the environment is created, activate it and install Connectome Mapper 3 with `PyPI` as follows:
 
 ```bash
-$ conda activate py37cmp-gui
-(py37cmp-gui)$ pip install connectomemapper
+$ conda activate py39cmp-gui
+(py39cmp-gui)$ pip install connectomemapper
 ```
 
 You are ready to use Connectome Mapper 3!
@@ -69,7 +69,7 @@ Please check [https://ohbm-environment.org](https://ohbm-environment.org) to lea
 
 ### Usage
 
-Having the `py37cmp-gui` conda environment previously installed activated, the BIDS App can easily be run using `connectomemapper3_docker`, the python wrapper for Docker, as follows:
+Having the `py39cmp-gui` conda environment previously installed activated, the BIDS App can easily be run using `connectomemapper3_docker`, the python wrapper for Docker, as follows:
 
 ```output
     usage: connectomemapper3_docker [-h]

--- a/cmp/cli/cmpbidsappmanager.py
+++ b/cmp/cli/cmpbidsappmanager.py
@@ -140,7 +140,7 @@ def main():
                 'To unfreeze the menubar on macOS, '
                 'click away from cmpbidsappmanager window to another app, '
                 'then reactivate cmpbidsappmanager. To avoid this problem, '
-                'please install python.app in the py37cmp-gui conda environment using:\n'
+                'please install python.app in the py39cmp-gui conda environment using:\n'
                 'conda install -c conda-forge python.app'
             )
             warnings.warn(msg)

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -1,19 +1,21 @@
-name: py37cmp-gui
+name: py39cmp-gui
 
 channels:
     - conda-forge
-    - aramislab
     - mrtrix3
 
 dependencies:
-    - python=3.7
-    - pip=21.3.1
+    - python=3.9
+    - pip=22.2
     - graphviz=2.50.0
     - dipy=1.3.0
     - fsleyes=1.3.3
-    - indexed_gzip=1.6.4
+    - indexed_gzip
     - mrtrix3=3.0.3
-    - git-annex=8.20211123
+    - git-annex=10.20220724
+    - qt=5.15.4
+    - pyqt=5.15.4
+    - pyqt5-sip=12.9.0
 
     - pip:
           - numpy==1.21.6
@@ -23,7 +25,6 @@ dependencies:
           - nipype==1.8.0
           - traits==6.3.2
           - traitsui==7.2.0
-          - PyQt5==5.15.6
           - duecredit==0.9.1
           - obspy==1.2.2
           - mne==0.24.1

--- a/conda/environment_macosx.yml
+++ b/conda/environment_macosx.yml
@@ -1,18 +1,20 @@
-name: py37cmp-gui
+name: py39cmp-gui
 
 channels:
     - conda-forge
-    - aramislab
     - mrtrix3
 
 dependencies:
-    - python=3.7
-    - pip=21.3.1
+    - python=3.9
+    - pip=22.2
     - graphviz=2.50.0
     - dipy=1.3.0
     - fsleyes=1.3.3
-    - indexed_gzip=1.6.4
+    - indexed_gzip
     - mrtrix3=3.0.3
+    - qt=5.15.4
+    - pyqt=5.15.4
+    - pyqt5-sip=12.9.0
 
     - pip:
           - numpy==1.21.6

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -27,8 +27,9 @@ dependencies:
     - coverage==5.2
     - duecredit==0.8.0
     - mne==0.24.1
-    - datalad[full]==0.15.4
-    - datalad-container==1.1.5
+    - mne_connectivity==0.3
+    - datalad[full]==0.17.2
+    - datalad-container==1.1.6
     - datalad-neuroimaging==0.3.1
     - pybids==0.14.0
     - statsmodels==0.11.1

--- a/docs/bidsappmanager.rst
+++ b/docs/bidsappmanager.rst
@@ -19,11 +19,11 @@ Start the Graphical User Interface
 
 In a terminal, enter to following::
 
-    $ source activate py37cmp-gui
+    $ source activate py39cmp-gui
 
 or::
 
-    $ conda activate py37cmp-gui
+    $ conda activate py39cmp-gui
 
 Please see Section :ref:`manual-install-cmpbidsappmanager` for more details about installation.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -374,7 +374,7 @@ intersphinx_mapping = {"http://docs.python.org/3": None}
 
 # -- sphinx-copybutton extension configuration -------------------------------
 
-copybutton_prompt_text = r">>> |\.\.\. |\$ | |\(py37cmp-gui\)\$ "
+copybutton_prompt_text = r">>> |\.\.\. |\$ | |\(py39cmp-gui\)\$ "
 copybutton_prompt_is_regexp = True
 # copybutton_only_copy_prompt_lines = False
 copybutton_remove_prompts = True

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -167,29 +167,29 @@ How to build the documentation locally
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 To generate the documentation:
 
-    1. Install the CMP3 conda environment ``py37cmp-gui``::
+    1. Install the CMP3 conda environment ``py39cmp-gui``::
 
         $ cd connectomemapper3
         $ conda env create -f environment.yml
 
-    2. Activate CMP3 conda environment ``py37cmp-gui``::
+    2. Activate CMP3 conda environment ``py39cmp-gui``::
 
-        $ conda activate py37cmp-gui
+        $ conda activate py39cmp-gui
 
     3. Install all dependencies such as sphinx and its extensions, required for the build::
 
-        (py37cmp-gui)$ pip install -r docs/requirements.txt
+        (py39cmp-gui)$ pip install -r docs/requirements.txt
 
     4. Install ``connectomemapper3``::
 
-        (py37cmp-gui)$ pip install .
+        (py39cmp-gui)$ pip install .
 
     5. Run the script ``scripts/build_docs.sh`` to generate the HTML documentation in ``docs/_build/html``::
 
-        (py37cmp-gui)$ sh scripts/build_docs.sh
+        (py39cmp-gui)$ sh scripts/build_docs.sh
 
     .. note::
-        Make sure to have (1) activated the conda environment ``py37cmp-gui`` and (2) reinstalled ``connectomemapper3`` with ``pip`` before running ``build_docs.sh``.
+        Make sure to have (1) activated the conda environment ``py39cmp-gui`` and (2) reinstalled ``connectomemapper3`` with ``pip`` before running ``build_docs.sh``.
 
 ------------
 

--- a/docs/datalad.rst
+++ b/docs/datalad.rst
@@ -25,12 +25,12 @@ Prerequisites
 --------------
 
 * Python3 must be installed with Datalad and all dependencies.
-  You can use the conda environment `py37cmp-gui` for instance.
-  See :ref:`Installation of py37cmp-gui <manual-install-cmpbidsappmanager>`
+  You can use the conda environment `py39cmp-gui` for instance.
+  See :ref:`Installation of py39cmp-gui <manual-install-cmpbidsappmanager>`
   for more installation details.
 
 * A recent version of `git-annex` and `liblzma` (included in
-  `py37cmp-gui` for Ubuntu/Debian).
+  `py39cmp-gui` for Ubuntu/Debian).
 
 * Docker must be installed on systems running Connectome Mapper 3.
   See :ref:`Prerequisites of Connectome Mapper 3 <manual-install-docker>`

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -133,15 +133,15 @@ The installation of the Connectome Mapper 3, including `cmpbidsappmanager`, cons
 
 *   Activate the conda environment::
 
-        $ source activate py37cmp-gui
+        $ source activate py39cmp-gui
 
   or::
 
-        $ conda activate py37cmp-gui
+        $ conda activate py39cmp-gui
 
 *   Install finally the latest released version of Connectome Mapper 3 with the Python Package Index (PyPI) using `pip`::
 
-        (py37cmp-gui)$ pip install connectomemapper
+        (py39cmp-gui)$ pip install connectomemapper
 
 *   You are ready to use the Connectome Mapper 3 (1) via its Graphical User Interface (GUI) aka CMP BIDS App Manager
     (See :ref:`guiusage` for the user guide), (2) via its python ``connectomemapper3_docker`` and

--- a/scripts/utils/build_docs.sh
+++ b/scripts/utils/build_docs.sh
@@ -8,10 +8,10 @@
 # Build the documentation using BASH shell interpreter and Sphinx doc generator.
 #
 # All python packages related to Sphinx necessary to build the docs
-# are provided in the `py37cmp-gui` conda environment described by
+# are provided in the `py39cmp-gui` conda environment described by
 # `environment.yml` / `environment_macosx.yml` files.
 #
-# Usage conda activate py37cmp-gui
+# Usage conda activate py39cmp-gui
 #       /bin/bash build_docs.sh
 #
 # Created by Sebastien Tourbier


### PR DESCRIPTION
This PR updates `conda/environment.yml` and `conda/environment_macosx.yml` to address:
- #206 

**Note:** It introduces an upgrade from python `3.7` to `3.9` which involved the renaming of the previous `py37cmp-gui` to `py39cmp-gui` to be consistent. References to `py37cmp-gui` has been changed in the documentation and the README.
